### PR TITLE
bug(order's-time):fix rendered order's time shown to the correct format

### DIFF
--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -10,6 +10,7 @@ const OrdersList = (props) => {
 
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
+        const fixedCreatedDate = createdDate.toLocaleTimeString();
         return (
             <div className="row view-order-container" key={order._id}>
                 <div className="col-md-4 view-order-left-col p-3">
@@ -17,7 +18,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {`${fixedCreatedDate}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
1. fixed the rendered order's time shown to the correct format

## Purpose
So the time wont have a messed up formatted time

## Approach
By fixing the time with a JS function

Closes #2
